### PR TITLE
Configure emacs for localdev using docker and LSP

### DIFF
--- a/init.el
+++ b/init.el
@@ -137,6 +137,8 @@ Check the warnings and messages buffers, or restart with --debug-init")
 (add-to-list 'package-archives
              (cons "gnu" exordium-gnu-package-repo) t)
 
+(setq package-user-dir (concat "~/.emacs.d/elpa-" emacs-version))
+
 (package-initialize)
 
 ;; Load the packages we need if they are not installed already
@@ -339,6 +341,12 @@ the .elc exists. Also discard .elc without corresponding .el"
 (use-package init-powerline :ensure nil
   :if (and exordium-theme exordium-enable-powerline))
 
+;; Docker
+(use-package init-docker :ensure nil)
+
+;;; LSP
+(use-package init-lsp :ensure nil :if exordium-lsp-mode-enable)
+
 (update-progress-bar)
 
 ;;; Greetings
@@ -346,6 +354,6 @@ the .elc exists. Also discard .elc without corresponding .el"
       (let ((current-user (split-string (user-full-name) " ")))
         (format ";; Happy hacking %s!
 
-" (if current-user (car current-user) exordium-current-user))))
+" (if current-user (car current-user) exordium-csurrent-user))))
 
 ;;; End of file

--- a/modules/init-bde-style.t.el
+++ b/modules/init-bde-style.t.el
@@ -875,7 +875,7 @@ int c)
     (should (equal (with-test-case-return tst (exordium-bde-bounds-of-arglist-at-point))
                    (cons 9 24)))))
 
-(ert-deftest test-exordium-bde-bounds-of-arglist-at-point-multi-line-4 ()
+(ert-deftest test-exordium-bde-bounds-of-arglist-at-point-multi-line-5 ()
   (let ((tst (make-test-case :input "Foo::Foo(bool b,
 int c)
 : b{b} {}"

--- a/modules/init-bde-style.t.el
+++ b/modules/init-bde-style.t.el
@@ -225,7 +225,7 @@ std::map<int, int> **dd = std::map<int, int>{});
 
 (ert-deftest test-bde-guess-class-name-class-2 ()
   (let ((tst (make-test-case :input "class TheName : public TheInterface {")))
-    (should (string= (with-test-casre-return tst (bde-guess-class-name))
+    (should (string= (with-test-case-return tst (bde-guess-class-name))
                      "class TheName"))))
 
 (ert-deftest test-bde-guess-class-name-struct-1 ()

--- a/modules/init-bde-style.t.el
+++ b/modules/init-bde-style.t.el
@@ -233,7 +233,7 @@ std::map<int, int> **dd = std::map<int, int>{});
     (should (string= (with-test-case-return tst (bde-guess-class-name))
                      "struct TheName"))))
 
-(ert-deftest test-bde-guess-class-name-class-2 ()
+(ert-deftest test-bde-guess-class-name-struct-2 ()
   (let ((tst (make-test-case :input "struct TheName : OtherStruct {")))
     (should (string= (with-test-case-return tst (bde-guess-class-name))
                      "struct TheName"))))

--- a/modules/init-company.el
+++ b/modules/init-company.el
@@ -8,6 +8,8 @@
   (setq rtags-completions-enabled t)
   ;; Turn on company mode everywhere
   (global-company-mode)
+  (add-to-list 'company-backends '(company-capf company-dabbrev))
+  (setq company-idle-delay nil)
   :bind
   (:map company-active-map
         ;; Use ESC to escape company-complete (in addition to C-g)
@@ -15,5 +17,12 @@
         ;; Key to force trigger company-complete
     :map global-map
         ("C-." . #'company-complete)))
+
+
+(use-package company-statistics
+  :ensure t
+  :after company
+  :init
+  (company-statistics-mode))
 
 (provide 'init-company)

--- a/modules/init-docker.el
+++ b/modules/init-docker.el
@@ -1,0 +1,14 @@
+;;;; Configuration of Docker related features
+
+(use-package docker
+  :bind ("C-c d" . docker))
+
+(use-package dockerfile-mode
+  :mode
+  ("Dockerfile\\'" . dockerfile-mode)
+  :config
+  (setq-default docker-use-sudo nil))
+
+(use-package docker-tramp)
+
+(provide 'init-docker)

--- a/modules/init-lsp.el
+++ b/modules/init-lsp.el
@@ -1,0 +1,104 @@
+;;; init-lsp --- Initialize LSP mode for Exordium
+
+;;; Commentary:
+
+;;; Code:
+
+(use-package flycheck
+  :commands flycheck-mode
+  :init (global-flycheck-mode))
+
+(use-package flycheck-pos-tip
+  :after flycheck
+  :defines flycheck-pos-tip-timeout
+  :hook (global-flycheck-mode . flycheck-pos-tip-mode)
+  :config (setq flycheck-pos-tip-timeout 30))
+
+;; set prefix for lsp-command-keymap (few alternatives - "C-l", "C-c l")
+(setq lsp-keymap-prefix exordium-lsp-keymap-prefix)
+
+(use-package lsp-mode
+  :if exordium-lsp-mode-enable
+  :hook ((c-mode-common  . lsp))
+  :init
+  (setq-default lsp-clients-clangd-executable
+                (seq-find #'executable-find exordium-lsp-clangd-executable))
+  :commands (lsp lsp-deferred)
+
+  :config
+  (if exordium-enable-which-key
+      (add-hook 'lsp-mode-hook #'lsp-enable-which-key-integration))
+  (setq lsp-clients-clangd-args exordium-lsp-clangd-args)
+  (setq lsp-diagnostic-package :flycheck)
+  (setq lsp-flycheck-live-reporting t)
+  ;; company mode configuration for lsp-mode
+  (setq lsp-completion-provider :capf)
+  (setq company-minimum-prefix-length 1
+        company-idle-delay 0.0)
+
+  ;; process buffer for the LSP server needs to be larger
+  (setq read-process-output-max (* 1024 1024)) ;; 1mb
+
+  ;; semantic hilite via lsp server
+  (setq lsp-enable-semantic-highlighting t)
+
+  (setq lsp-idle-delay 0.1) ;; clangd is fast
+
+  (setq treemacs-space-between-root-nodes nil))
+
+(use-package lsp-ui
+  :after lsp-mode
+  :init
+  (setq lsp-ui-doc-enable exordium-lsp-ui-doc-enable
+        lsp-ui-doc-use-childframe t
+        lsp-ui-doc-position exordium-lsp-ui-doc-position
+        lsp-ui-doc-include-signature t
+        lsp-ui-sideline-enable exordium-lsp-ui-sideline-enable
+        lsp-ui-sideline-show-code-actions t
+        lsp-ui-sideline-show-hover t
+        lsp-ui-flycheck-enable exordium-lsp-ui-flycheck-enable
+        lsp-ui-flycheck-list-position exordium-lsp-ui-flycheck-list-position
+        lsp-ui-peek-enable exordium-lsp-ui-peek-enable
+        )
+  :commands lsp-ui-mode)
+
+(use-package helm-xref
+  :ensure t
+  :after helm
+  :if exordium-helm-everywhere
+  :commands helm-xref
+  :config
+  (setq xref-show-xrefs-function 'helm-xref-show-xrefs))
+
+(use-package helm-lsp
+  :after (lsp-mode helm)
+  :if exordium-helm-everywhere
+  :commands
+  (helm-lsp-workspace-symbol
+   helm-lsp-global-workspace-symbol
+   helm-lsp-code-actions))
+
+(use-package lsp-treemacs
+  :after lsp-mode
+  :commands lsp-treemacs-errors-list)
+
+(use-package dap-mode
+  :requires (dap-lldb dap-cpptools dap-gdb-lldb)
+  :init
+  (setq lsp-enable-dap-auto-configure t)
+  :config
+  (require 'dap-cpptools)
+  (require 'dap-lldb)
+  (require 'dap-gdb-lldb)
+  (dap-ui-mode 1)
+  (dap-tooltip-mode 1)
+  :commands dap-mode)
+
+(use-package which-key
+  :if exordium-enable-which-key
+  :config
+  (which-key-mode))
+
+
+(provide 'init-lsp)
+;;; init-lsp.el ends here

--- a/modules/init-prefs.el
+++ b/modules/init-prefs.el
@@ -563,4 +563,83 @@ configuration load slower."
 
 
 
+
+;;; LSP
+(defun exordium--string-vector-p (candidate)
+  "Returns true if CANDIDATE is a vector data structure and
+every element of it is of type string, else nil."
+  (and
+   (vectorp candidate)
+   (seq-every-p #'stringp candidate)))
+
+(define-widget 'exordium-string-vector 'lazy
+  "A vector of zero or more elements, every element of which is a string.
+Appropriate for any language-specific `defcustom' that needs to
+serialize as a JSON array of strings."
+  :offset 4
+  :tag "Vector"
+  :type '(restricted-sexp
+          :match-alternatives (exordium--string-vector-p)))
+
+(defcustom exordium-lsp-clangd-executable ["clangd-15" "clangd-14" "clangd-13" "clangd-12" "clangd-11" "clangd-10" "clangd-9" "clangd"]
+  "List of executable names to search for to run clangd.
+Default is to choose the first that is found via `executable-find'."
+  :group 'exordium
+  :risky t
+  :type 'exordium-string-vector)
+
+(defcustom exordium-lsp-clangd-args '("-j=4" "--background-index" "--log=error" "--clang-tidy")
+  "Extra arguments for the clangd executable."
+  :group 'exordium
+  :risky t
+  :type '(repeat string))
+
+(defcustom exordium-enable-which-key t
+  "If t, which-key mode will be enabled."
+  :group 'exordium
+  :type  'boolean)
+
+(defcustom exordium-lsp-ui-doc-enable t
+  "If t, exordium-lsp-ui-doc mode will be enabled."
+  :group 'exordium
+  :type  'boolean)
+
+(defcustom exordium-lsp-ui-sideline-enable t
+  "If t, exordium-lsp-ui-sideline mode will be enabled."
+  :group 'exordium
+  :type  'boolean)
+
+(defcustom exordium-lsp-ui-flycheck-enable t
+  "If t, exordium-lsp-ui-flycheck mode will be enabled."
+  :group 'exordium
+  :type  'boolean)
+
+(defcustom exordium-lsp-ui-peek-enable t
+  "If t, exordium-lsp-ui-peek mode will be enabled."
+  :group 'exordium
+  :type  'boolean)
+
+(defcustom exordium-lsp-keymap-prefix "C-c l"
+  "The prefix to bind the lsp keymap to, `kbd' format."
+  :group 'exordium
+  :type  'string)
+
+(defcustom exordium-lsp-ui-doc-position 'bottom
+  "Where to display the doc in LSP mode."
+  :group 'exordium
+  :type '(choice (const :tag "Top" top)
+                 (const :tag "Bottom" bottom)
+                 (const :tag "At point" at-point)))
+
+(defcustom exordium-lsp-ui-flycheck-list-position 'bottom
+  "Position where `lsp-ui-flycheck-list' will show diagnostics for the workspace."
+  :group 'exordium
+  :type '(choice (const :tag "Bottom" bottom)
+                 (const :tag "Right" right)))
+
+(defcustom exordium-lsp-mode-enable t
+  "Enable lsp-mode."
+  :group 'exordium
+  :type 'boolean)
+
 (provide 'init-prefs)


### PR DESCRIPTION
Configure LSP mode and related packages to provide an equivalent to vscode for
"localdev" with LSP support for clangd and docker modes.