### PR TITLE
Add Tree-sitter support pre emacs-29

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   ci-tests:
     runs-on: ${{ matrix.os }}
+    env:
+      ci_tests: true
     strategy:
       matrix:
         os:


### PR DESCRIPTION
Also: make hook forwarding. Not sure if it is not evaluated to early though, as some hooks may not exist yet. Perhaps wrapping the `mapc` in `eval-after-load` or forcing modes to load?