### PR TITLE
Use ci_tests at top-level

### DIFF
--- a/modules/init-treesit.el
+++ b/modules/init-treesit.el
@@ -2,26 +2,9 @@
 
 ;;;; Configuration for Treesitter
 
-(if (and (version< "29" emacs-version ) (treesit-available-p))
-    (unless (getenv "ci_tests")
-      (progn
-        (use-package tree-sitter-langs)
-        (use-package tree-sitter
-          :diminish
-          :after (tree-sitter-langs)
-          :hook
-          (tree-sitter-after-on . tree-sitter-hl-mode)
-          :custom
-          (font-lock-maximum-decoration t)
-          :config
-          (when-let ((language-name (alist-get 'ruby-mode
-                                               tree-sitter-major-mode-language-alist)))
-            (add-to-list 'tree-sitter-major-mode-language-alist
-                         (cons 'enh-ruby-mode language-name)))
-          (add-to-list 'tree-sitter-major-mode-language-alist
-                       (cons 'forge-post-mode 'markdown))
-          (global-tree-sitter-mode)))
-
+(unless (getenv "ci_tests")
+(if (and (version< "29" emacs-version) (treesit-available-p))
+    (progn
       (defun exordium--add-forward-ts-hook (mode)
         (when-let ((ts-hook (intern (concat (symbol-name mode) "-ts-mode-hook")))
                    (hook (intern (concat (symbol-name mode) "-mode-hook")))
@@ -55,6 +38,24 @@
                 rust
                 scala
                 ))
-        (setq treesit-font-lock-level 4))))
+        (setq treesit-font-lock-level 4)))
+
+  (use-package tree-sitter-langs)
+  (use-package tree-sitter
+    :diminish
+    :after (tree-sitter-langs)
+    :hook
+    (tree-sitter-after-on . tree-sitter-hl-mode)
+    :custom
+    (font-lock-maximum-decoration t)
+    :config
+    (when-let ((language-name (alist-get 'ruby-mode
+                                         tree-sitter-major-mode-language-alist)))
+      (add-to-list 'tree-sitter-major-mode-language-alist
+                   (cons 'enh-ruby-mode language-name)))
+    (add-to-list 'tree-sitter-major-mode-language-alist
+                 (cons 'forge-post-mode 'markdown))
+    (global-tree-sitter-mode)))
+) ;; (unless (getenv "ci_tests")
 
 (provide 'init-treesit)


### PR DESCRIPTION
It seems that treesitter is incompatible with exordium's CI. Well - maybe the 29 could be made to do so, but I don't have it yet to fiddle with it. For that I moved `ci_tests` to the top level and have hidden all treesitter configuration.

Also: it seems that the last [commit](ad51c1c54cdff1da3f7777b2d15a76ec299bba4e) reduced both branches to `t` branch, only executed for Emacs 29 and treesitter. I reversed the order, and I hope untangled the branches.
